### PR TITLE
Revert 	valueless change

### DIFF
--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -50,7 +50,7 @@ Please see the following rules for detailed functional naming patterns:
 * <<213>>
 
 [#129]
-== {MUST} Use lowercase separate words for Path Segments
+== {MUST} Use lowercase separate words with hyphens for Path Segments
 
 Example:
 


### PR DESCRIPTION
Example uses hyphens (as well as your internal code) and so why remove
this from the rule/title.